### PR TITLE
Create internal LoadBalancer with nginx-ingress fixes #3

### DIFF
--- a/part-2/nginx-ingress/values.yaml
+++ b/part-2/nginx-ingress/values.yaml
@@ -3,7 +3,9 @@ controller:
     enabled: true
   service:
     enabled: true
-    type: ClusterIP
+    type: LoadBalancer
+    annotations:
+      cloud.google.com/load-balancer-type: "Internal"
   metrics:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
Addind specific annotation to controller service creates Internal LoadBalancer in GCP